### PR TITLE
Default configuration for official Cucumber Visual Studio Code extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["cucumberopen.cucumber-official"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "cucumber.glue": [
+        "cypress/e2e/steps/**/*.ts"
+    ],
+    "cucumber.features": [
+        "cypress/e2e/features/**/*.feature"
+    ]
+}


### PR DESCRIPTION
Providing smart configuration defaults to run the official Cucumber Visual Studio Code extension against this repository, will improve development and onboarding (cucumber/vscode#188) when using that integrated development environment with this project.

The `.vscode` reference in the `.gitignore` has been left untouched to allow workspace settings to be extended or modified without being tracked by git.